### PR TITLE
Justinian Plague and epidemic diseases #96

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -11,7 +11,7 @@ This release is save-game compatible with v0.9.6
 
 MAJOR:
 - Activated vanilla epidemic diseases in the mod timeframe.
-- Added the Plague of Justinian epidemic (bubonic plague) that may occur once in the 6th century.
+- Added the Plague of Justinian epidemic (bubonic plague) that may occur once in the 6th century, with possible recurrence during 7th and 8th century
 - Fixed CTD when typing some letters in Find Title, due to some empty custom regions
 
 MINOR:

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,7 +10,8 @@ Next v0.9.6.1
 This release is save-game compatible with v0.9.6
 
 MAJOR:
-- Added missing nerf of diseases of patch 2.4.3
+- Activated vanilla epidemic diseases in the mod timeframe.
+- Added the Plague of Justinian epidemic (bubonic plague) that may occur once in the 6th century.
 - Fixed CTD when typing some letters in Find Title, due to some empty custom regions
 
 MINOR:

--- a/WTWSMS/common/disease/00_disease.txt
+++ b/WTWSMS/common/disease/00_disease.txt
@@ -101,7 +101,7 @@ measles = {
 	always_get_message = no
 	
 	timeperiod = {
-		start_date = 1.1.1
+		start_date = 500.1.1
 		end_date = 1452.1.1
 
 		one_only = no

--- a/WTWSMS/common/disease/00_disease.txt
+++ b/WTWSMS/common/disease/00_disease.txt
@@ -13,7 +13,7 @@ tuberculosis = {
 	always_get_message = no
 
 	timeperiod = {
-		start_date = 769.1.1
+		start_date = 1.1.1
 		end_date = 1452.1.1		
 
 		one_only = no
@@ -35,7 +35,7 @@ typhoid_fever = {
 	always_get_message = no
 	
 	timeperiod = {
-		start_date = 769.1.1
+		start_date = 1.1.1
 		end_date = 1452.1.1
 
 		one_only = no
@@ -57,7 +57,7 @@ typhus = {
 	always_get_message = no
 	
 	timeperiod = {
-		start_date = 769.1.1
+		start_date = 1.1.1
 		end_date = 1452.1.1
 
 		one_only = no
@@ -101,7 +101,7 @@ measles = {
 	always_get_message = no
 	
 	timeperiod = {
-		start_date = 769.1.1
+		start_date = 1.1.1
 		end_date = 1452.1.1
 
 		one_only = no
@@ -123,7 +123,7 @@ small_pox = {
 	always_get_message = no
 	
 	timeperiod = {
-		start_date = 769.1.1
+		start_date = 1.1.1
 		end_date = 1452.1.1
 
 		one_only = no

--- a/WTWSMS/common/disease/WTWSMS_disease.txt
+++ b/WTWSMS/common/disease/WTWSMS_disease.txt
@@ -1,0 +1,23 @@
+# Justinian plague (541 A.D.) is regarded as the 1st occurrence of the bubonic plague.
+# https://en.wikipedia.org/wiki/Plague_of_Justinian
+justinian_plague = {
+	contagiousness = 0.95
+	outbreak_chance = 0.01
+	effect = {
+		city_tax_modifier = -0.8
+		supply_limit = -4
+		max_attrition = 0.05
+	}
+	icon = 4
+	tooltip = JUSTINIAN_PLAGUE_INFO
+	months = 10
+	trait = has_bubonic_plague
+	always_get_message = yes
+
+	timeperiod = {
+		start_date = 500.1.1
+		end_date = 600.1.1
+
+		one_only = yes
+	}
+}

--- a/WTWSMS/common/disease/WTWSMS_disease.txt
+++ b/WTWSMS/common/disease/WTWSMS_disease.txt
@@ -1,5 +1,7 @@
 # Justinian plague (541 A.D.) is regarded as the 1st occurrence of the bubonic plague.
 # https://en.wikipedia.org/wiki/Plague_of_Justinian
+
+# Initial outbreak
 justinian_plague = {
 	contagiousness = 0.95
 	outbreak_chance = 0.01
@@ -17,6 +19,52 @@ justinian_plague = {
 	timeperiod = {
 		start_date = 500.1.1
 		end_date = 600.1.1
+
+		one_only = yes
+	}
+}
+
+# 1st recurrence of the plague (shorter outbreak)
+justinian_plague_recurrence_1 = {
+	contagiousness = 0.95
+	outbreak_chance = 0.01
+	effect = {
+		city_tax_modifier = -0.7
+		supply_limit = -4
+		max_attrition = 0.05
+	}
+	icon = 4
+	tooltip = JUSTINIAN_PLAGUE_INFO
+	months = 8
+	trait = has_bubonic_plague
+	always_get_message = yes
+
+	timeperiod = {
+		start_date = 600.1.1
+		end_date = 700.1.1
+
+		one_only = yes
+	}
+}
+
+# 2nd recurrence of the plague (shorter outbreak)
+justinian_plague_recurrence_2 = {
+	contagiousness = 0.95
+	outbreak_chance = 0.01
+	effect = {
+		city_tax_modifier = -0.6
+		supply_limit = -4
+		max_attrition = 0.05
+	}
+	icon = 4
+	tooltip = JUSTINIAN_PLAGUE_INFO
+	months = 6
+	trait = has_bubonic_plague
+	always_get_message = yes
+
+	timeperiod = {
+		start_date = 700.1.1
+		end_date = 800.1.1
 
 		one_only = yes
 	}

--- a/WTWSMS/common/religion_modifiers/WtWSMS_religion_modifiers.txt
+++ b/WTWSMS/common/religion_modifiers/WtWSMS_religion_modifiers.txt
@@ -8,3 +8,8 @@ destroyed_holy_tree = {
 	authority = 3
 	years = 20
 }
+
+affected_by_pestilence = {
+	authority = -20
+	years = 5
+}

--- a/WTWSMS/events/WtWSMS_disease_events.txt
+++ b/WTWSMS/events/WtWSMS_disease_events.txt
@@ -1,3 +1,10 @@
+###############################
+# Disease events
+#
+# ds.1 -> ds.9 Quarantine events
+# ds.10 -> ds.29 Justinian plague
+###############################
+
 namespace = ds
 
 # Jews Expelled
@@ -68,7 +75,7 @@ character_event = {
 		name = EVTOPTA_ds_3
 		trigger = {
 			NOT = { has_character_modifier = borrowed_from_jews }
-			}
+		}
 			
 	}
 }
@@ -150,5 +157,197 @@ character_event = {
 	option = {
 		name = EVTOPTA_ds_7
 		prestige = 50
+	}
+}
+
+###############################
+# Justinian Plague
+#
+# Written by Romulien
+###############################
+
+# Arrival of the plague
+
+# Plague arrives in the realm
+# Note: there is no way to check a province for a specific epidemic, so use traits.
+character_event = {
+	id = ds.10
+	hide_window = yes
+	
+	only_rulers = yes
+	only_independent = yes
+
+	trigger = {
+		primary_title = {
+			NOT = { has_title_flag = flag_justinian_plague_arrived_in_realm }
+		}
+		any_realm_character = {
+			trait = has_bubonic_plague
+		}
+	}
+	
+	mean_time_to_happen = {
+		days = 1
+	}
+	
+	immediate = {
+		primary_title = {
+			set_title_flag = flag_justinian_plague_arrived_in_realm
+		}
+	}
+	
+	option = {
+		name = OK
+
+		if = {
+			limit = {
+				primary_title = {
+					is_titular = no
+				}
+				NOT = { has_global_flag = flag_justinian_plague_arrived }
+			}
+			any_playable_ruler = {
+				limit = { 
+					ai = no
+					NOT = { character = ROOT }
+				}
+				narrative_event = { id = ds.11 days = 30 }
+			}
+			set_global_flag = flag_justinian_plague_arrived
+		}
+		
+		narrative_event = { id = ds.12 }
+		any_realm_character = {
+			limit = { 
+				ai = no
+			}
+			narrative_event = { id = ds.12 }
+		}
+	}
+}
+
+# Notify players of the arrival of the plague in the world
+# FROM is the independent liege of the initial outbreak
+narrative_event = {
+	id = ds.11
+	desc = ds.11.desc
+	title = EVTTITLE_bubonic_plague
+	
+	picture = GFX_evt_plague_doctor
+	border = GFX_event_narrative_frame_religion
+
+	is_triggered_only = yes
+	
+	option = {
+		name = ds.11.a
+		trigger = {
+			NOT = { trait = zealous }
+		}
+	}
+	
+	option = {
+		name = ds.11.b
+		tooltip_info = zealous
+		trigger = {
+			trait = zealous
+		}
+	}
+}
+
+# Notify rulers that plague arrived in the realm
+# FROM is the top liege
+narrative_event = {
+	id = ds.12
+	desc = ds.12.desc
+	title = EVTTITLE_bubonic_plague
+	
+	picture = GFX_evt_plague_doctor
+	border = GFX_event_narrative_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = ds.12.a
+		
+		random = {
+			chance = 10
+			modifier = {
+				factor = 3
+				trait = zealous
+			}
+			add_trait = depressed
+		}
+	}
+}
+
+
+
+# Religious head gets the plague
+character_event = {
+	id = ds.13
+	desc = ds.13.desc
+	
+	picture = GFX_evt_plague_doctor
+	border = GFX_event_narrative_frame_religion
+	
+	only_rulers = yes
+	
+	trigger = {
+		controls_religion = yes
+		trait = has_bubonic_plague
+		NOT = { intrigue = 12 } # Unsuccessful at concealing it
+		NOT = { has_character_flag = flag_affected_by_pestilence }
+	}
+		
+	mean_time_to_happen = {
+		days = 1
+	}
+	
+	immediate = {
+		set_character_flag = flag_affected_by_pestilence
+	}
+	
+	option = {
+		name = ds.13.a
+		religion_authority = { modifier = affected_by_pestilence }
+		
+		any_playable_ruler = {
+			limit = {
+				ai = no
+				OR = {
+					NOT = { character = ROOT }
+					religion = ROOT
+					is_heresy_of = ROOT
+				}
+			}
+			narrative_event = { id = ds.14 }
+		}
+	}
+}
+
+# Notify the player
+# FROM is the religious head
+narrative_event = {
+	id = ds.14
+	desc = ds.14.desc
+	title = EVTTITLE_bubonic_plague
+	
+	picture = GFX_evt_plague_doctor
+	border = GFX_event_narrative_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = ds.14.a
+		trigger = {
+			religion = FROM
+		}
+	}
+	
+	option = {
+		name = ds.14.b
+		trigger = {
+			is_heresy_of = FROM
+		}
 	}
 }

--- a/WTWSMS/events/WtWSMS_disease_events.txt
+++ b/WTWSMS/events/WtWSMS_disease_events.txt
@@ -314,8 +314,8 @@ character_event = {
 		any_playable_ruler = {
 			limit = {
 				ai = no
+				NOT = { character = ROOT }
 				OR = {
-					NOT = { character = ROOT }
 					religion = ROOT
 					is_heresy_of = ROOT
 				}

--- a/WTWSMS/events/WtWSMS_disease_events.txt
+++ b/WTWSMS/events/WtWSMS_disease_events.txt
@@ -179,7 +179,10 @@ character_event = {
 
 	trigger = {
 		primary_title = {
-			NOT = { has_title_flag = flag_justinian_plague_arrived_in_realm }
+			OR = {
+				NOT = { has_title_flag = flag_justinian_plague_arrived_in_realm } # Initial outbreak
+				had_title_flag = { flag = flag_justinian_plague_arrived_in_realm days = 365 } # Recurrence of the plague
+			}	
 		}
 		any_realm_character = {
 			trait = has_bubonic_plague
@@ -192,19 +195,38 @@ character_event = {
 	
 	immediate = {
 		primary_title = {
+			clr_title_flag = flag_justinian_plague_arrived_in_realm # Reset the counter
 			set_title_flag = flag_justinian_plague_arrived_in_realm
 		}
 	}
 	
 	option = {
 		name = OK
+		
+		if = {
+			limit = {
+				had_global_flag = { flag = flag_justinian_plague_arrived days = 3650 } # Recurrence of the plague
+				primary_title = {
+					is_titular = no # Let the notification fire for a landed title
+				}
+			}
+			any_playable_ruler = {
+				limit = { 
+					ai = no
+					NOT = { character = ROOT }
+				}
+				narrative_event = { id = ds.15 days = 30 }
+			}
+			clr_global_flag = flag_justinian_plague_arrived # Reset counter
+			set_global_flag = flag_justinian_plague_arrived
+		}
 
 		if = {
 			limit = {
+				NOT = { has_global_flag = flag_justinian_plague_arrived } # Initial outbreak
 				primary_title = {
-					is_titular = no
+					is_titular = no # Let the notification fire for a landed title
 				}
-				NOT = { has_global_flag = flag_justinian_plague_arrived }
 			}
 			any_playable_ruler = {
 				limit = { 
@@ -213,6 +235,8 @@ character_event = {
 				}
 				narrative_event = { id = ds.11 days = 30 }
 			}
+			# Note: global flag is also set via e_byzantium title history
+			# With a start date 542-600, the initial outbreak will just be considered a recurrence of the plague.
 			set_global_flag = flag_justinian_plague_arrived
 		}
 		
@@ -232,11 +256,18 @@ narrative_event = {
 	id = ds.11
 	desc = ds.11.desc
 	title = EVTTITLE_bubonic_plague
-	
+
 	picture = GFX_evt_plague_doctor
 	border = GFX_event_narrative_frame_religion
 
 	is_triggered_only = yes
+	
+	immediate = {
+		primary_title = {
+			clr_title_flag = flag_justinian_plague_arrived_in_realm # Reset the counter
+			set_title_flag = flag_justinian_plague_arrived_in_realm
+		}
+	}
 	
 	option = {
 		name = ds.11.a
@@ -348,6 +379,34 @@ narrative_event = {
 		name = ds.14.b
 		trigger = {
 			is_heresy_of = FROM
+		}
+	}
+}
+
+# Notify players of the recurrence of the plague in the world
+# FROM is the independent liege of the initial outbreak
+narrative_event = {
+	id = ds.15
+	desc = ds.15.desc
+	title = EVTTITLE_bubonic_plague
+
+	picture = GFX_evt_plague_doctor
+	border = GFX_event_narrative_frame_religion
+
+	is_triggered_only = yes
+	
+	option = {
+		name = ds.11.a
+		trigger = {
+			NOT = { trait = zealous }
+		}
+	}
+	
+	option = {
+		name = ds.11.b
+		tooltip_info = zealous
+		trigger = {
+			trait = zealous
 		}
 	}
 }

--- a/WTWSMS/history/titles/e_byzantium.txt
+++ b/WTWSMS/history/titles/e_byzantium.txt
@@ -237,6 +237,9 @@
 527.8.1={
 	holder=70512
 }
+542.1.1={
+	set_global_flag = flag_justinian_plague_arrived
+}
 565.11.14={
 	holder=70511
 }

--- a/WTWSMS/localisation/WtWSMS_events.csv
+++ b/WTWSMS/localisation/WtWSMS_events.csv
@@ -296,6 +296,7 @@ ds.13.a;[Root.Religion.GetHighGodNameCap] has abandoned us...;;;;;;;;;;;x
 ds.14.desc;Rumors are spreading that the [From.GetTitledName] has become plague-stricken. In these difficult times the [From.Religion.GetName] followers were hoping for guidance and hope, and now the moral authority of the religion is weakened.;;;;;;;;;;;x
 ds.14.a;Certainly the hand of [Root.Religion.GetRandomEvilGodName], we are doomed !;;;;;;;;;;;x
 ds.14.b;A sign that [Root.Religion.GetName] is the true religion !;;;;;;;;;;;x
+ds.15.desc;There are rumors that a terrible plague has reappeared in the [From.PrimaryTitle.GetFullName], leaving a trail of desolation in its wake. The symptoms ressemble the ones of the Great Plague...;;;;;;;;;;;x
 EVTDESC_spirit.1;The various practitioners of Germanic Paganism have deviated enough due to their isolation that there are enough cultural differences to warrant separate religions. The divide is strongest between the North, West, and Central Germans.;;;;;;;;;;;x
 EVTOPTAspirit.1;Horrible!;;;;;;;;;;;x
 EVTOPTBspirit.1;Fools...;;;;;;;;;;;x

--- a/WTWSMS/localisation/WtWSMS_events.csv
+++ b/WTWSMS/localisation/WtWSMS_events.csv
@@ -285,6 +285,17 @@ EVTDESC_ds_6;You have ordered the Quaranta placed on all trade posts in the Repu
 EVTOPTA_ds_6;Wonderful!;;;;;;;;;;;x
 EVTDESC_ds_7;The people of Rome have adapted well to live in the Quarantine. Those showing symptoms have been isolated in the Colosseum, and the guards have kept anarchy to a minimum.;;;;;;;;;;;x
 EVTOPTA_ds_7;Excellent News!;;;;;;;;;;;x
+EVTTITLE_bubonic_plague;The Bubonic Plague;;;;;;;;;;;x
+ds.11.desc;There are rumours of a terrible plague spreading in the [From.PrimaryTitle.GetFullName], leaving a trail of desolation in its wake. The pestilence is like nothing ever seen before.;;;;;;;;;;;x
+ds.11.a;May [Root.Religion.GetHighGodName] prevent the pestilence from ever reaching our realm...;;;;;;;;;;;x
+ds.11.b;[Root.Religion.GetHighGodNameCap] will protect us!;;;;;;;;;;;x
+ds.12.desc;The pestilence is sweeping through the whole known world and has reached the realm. Symptoms appear to be fever, headaches, vomiting, necrosis of the hands,... Doctors are helpless and very few infected people manage to survive. Farmers can't take care of crops and the price of grain is rising.;;;;;;;;;;;x
+ds.12.a;[Root.Religion.GetHighGodNameCap] has abandoned us...;;;;;;;;;;;x
+ds.13.desc;As a religious head, being contaminated by the pestilence will have a profound impact on your authority. In these difficult times the [Root.Religion.GetName] followers were hoping you would provide guidance and hope.;;;;;;;;;;;x
+ds.13.a;[Root.Religion.GetHighGodNameCap] has abandoned us...;;;;;;;;;;;x
+ds.14.desc;Rumors are spreading that the [From.GetTitledName] has become plague-stricken. In these difficult times the [From.Religion.GetName] followers were hoping for guidance and hope, and now the moral authority of the religion is weakened.;;;;;;;;;;;x
+ds.14.a;Certainly the hand of [Root.Religion.GetRandomEvilGodName], we are doomed !;;;;;;;;;;;x
+ds.14.b;A sign that [Root.Religion.GetName] is the true religion !;;;;;;;;;;;x
 EVTDESC_spirit.1;The various practitioners of Germanic Paganism have deviated enough due to their isolation that there are enough cultural differences to warrant separate religions. The divide is strongest between the North, West, and Central Germans.;;;;;;;;;;;x
 EVTOPTAspirit.1;Horrible!;;;;;;;;;;;x
 EVTOPTBspirit.1;Fools...;;;;;;;;;;;x

--- a/WTWSMS/localisation/WtWSMS_events.csv
+++ b/WTWSMS/localisation/WtWSMS_events.csv
@@ -286,7 +286,7 @@ EVTOPTA_ds_6;Wonderful!;;;;;;;;;;;x
 EVTDESC_ds_7;The people of Rome have adapted well to live in the Quarantine. Those showing symptoms have been isolated in the Colosseum, and the guards have kept anarchy to a minimum.;;;;;;;;;;;x
 EVTOPTA_ds_7;Excellent News!;;;;;;;;;;;x
 EVTTITLE_bubonic_plague;The Bubonic Plague;;;;;;;;;;;x
-ds.11.desc;There are rumours of a terrible plague spreading in the [From.PrimaryTitle.GetFullName], leaving a trail of desolation in its wake. The pestilence is like nothing ever seen before.;;;;;;;;;;;x
+ds.11.desc;There are rumors of a terrible plague spreading in the [From.PrimaryTitle.GetFullName], leaving a trail of desolation in its wake. The pestilence is like nothing ever seen before.;;;;;;;;;;;x
 ds.11.a;May [Root.Religion.GetHighGodName] prevent the pestilence from ever reaching our realm...;;;;;;;;;;;x
 ds.11.b;[Root.Religion.GetHighGodNameCap] will protect us!;;;;;;;;;;;x
 ds.12.desc;The pestilence is sweeping through the whole known world and has reached the realm. Symptoms appear to be fever, headaches, vomiting, necrosis of the hands,... Doctors are helpless and very few infected people manage to survive. Farmers can't take care of crops and the price of grain is rising.;;;;;;;;;;;x
@@ -342,7 +342,7 @@ EVTDESCFRANKS.2;With the death of, [FromFrom.GetTitledFirstName] the reign of th
 EVTOPTAFRANKS.2;The Crown is Mine!;;;;;;;;;;;x
 EVTTOOLTIP_FRANKS_2;Hold Fast!;;;;;;;;;;;x
 EVTOPTBFRANKS.2;I shall stand down...;;;;;;;;;;;x
-EVTNAMEFRANKS.3;Inter Regnum;;;;;;;;;;;x
+EVTNAMEFRANKS.3;Interregnum;;;;;;;;;;;x
 EVTDESCFRANKS.3;With the end of the old ruling dynasty, the new ruler, [From.GetTitledFirstName], has decided to renounce the Crown, seeing his illegitimacy. Now, all his formal vassals are independent, and you now control your own fate.;;;;;;;;;;;x
 EVTOPTAFRANKS.3;An interesting development...;;;;;;;;;;;x
 EVTNAMEFRANKS.4;Age of Tyranny!;;;;;;;;;;;x

--- a/WTWSMS/localisation/WtWSMS_misc.csv
+++ b/WTWSMS/localisation/WtWSMS_misc.csv
@@ -1,0 +1,4 @@
+#CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
+#### Stuff that doesn't fit into a specific category
+justinian_plague;Bubonic Plague;Peste bubonique;Beulenpest;;Peste bubónica;;;;;;;;;x
+JUSTINIAN_PLAGUE_INFO;A terrible plague is devastating this county;;;;;;;;;;;;x

--- a/WTWSMS/localisation/WtWSMS_misc.csv
+++ b/WTWSMS/localisation/WtWSMS_misc.csv
@@ -2,6 +2,8 @@
 #### Stuff that doesn't fit into a specific category;;;;;;;;;;;;x
 #### Diseases;;;;;;;;;;;;x
 justinian_plague;Bubonic Plague;Peste bubonique;Beulenpest;;Peste bubónica;;;;;;;;;x
+justinian_plague_recurrence_1;Bubonic Plague;Peste bubonique;Beulenpest;;Peste bubónica;;;;;;;;;x
+justinian_plague_recurrence_2;Bubonic Plague;Peste bubonique;Beulenpest;;Peste bubónica;;;;;;;;;x
 JUSTINIAN_PLAGUE_INFO;A terrible plague is devastating this county.;;;;;;;;;;;;x
 #### Religious modifiers;;;;;;;;;;;;x
 affected_by_pestilence;Affected by the pestilence;;;;;;;;;;;;x

--- a/WTWSMS/localisation/WtWSMS_misc.csv
+++ b/WTWSMS/localisation/WtWSMS_misc.csv
@@ -1,4 +1,7 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
-#### Stuff that doesn't fit into a specific category
+#### Stuff that doesn't fit into a specific category;;;;;;;;;;;;x
+#### Diseases;;;;;;;;;;;;x
 justinian_plague;Bubonic Plague;Peste bubonique;Beulenpest;;Peste bubónica;;;;;;;;;x
-JUSTINIAN_PLAGUE_INFO;A terrible plague is devastating this county;;;;;;;;;;;;x
+JUSTINIAN_PLAGUE_INFO;A terrible plague is devastating this county.;;;;;;;;;;;;x
+#### Religious modifiers;;;;;;;;;;;;x
+affected_by_pestilence;Affected by the pestilence;;;;;;;;;;;;x


### PR DESCRIPTION
- Activate epidemic diseases by extending start_date to 1.1.1 as they were already present in the antiquity (except measles - 500 A.D.).
- Add the Justinian plague as a 1 time occurrence of  bubonic plague in the 6th century. Note: was discussed [in the old forum thread](https://forum.paradoxplaza.com/forum/index.php?threads/when-the-world-stopped-making-sense-a-480-migrational-period-mod.772971/page-172#post-17635909).
- Recurrence of the plague in the 7th and 8th century.
- Add narrative events to notify player when:
  - Plague appears in the world
  - Plague appears in the realm
  - Religious head is contaminated, lowering moral authority (note: may not fire if character dies too quickly)

I was able to test by manually changing outbreak_chance from 0.01 to 1, and loading a 6th century bookmark.