### PR TITLE
Fix duplicate problem in wikipedia links

### DIFF
--- a/WTWSMS/localisation/WikipediaLinks.csv
+++ b/WTWSMS/localisation/WikipediaLinks.csv
@@ -36,8 +36,7 @@ W_L_170128;https://en.wikipedia.org/wiki/Loarn_mac_Eirc;https://fr.wikipedia.org
 W_L_170129;https://en.wikipedia.org/wiki/Fergus_M%C3%B3r;https://fr.wikipedia.org/wiki/Fergus_Ier_de_Dal_Riada;;;;;;;;;;;x
 W_L_190008;https://en.wikipedia.org/wiki/Anicius_Acilius_Aginantius_Faustus;;;;;;;;;;;;x
 W_L_190015;https://en.wikipedia.org/wiki/Aegidius;https://fr.wikipedia.org/wiki/%C3%86gidius;;;;;;;;;;;x
-# DOUBLE with W_L_63:
-W_L_190215;https://en.wikipedia.org/wiki/Theoderic_the_Great;https://fr.wikipedia.org/wiki/Th%C3%A9odoric_le_Grand;;;;;;;;;;;x
+W_L_190215;https://en.wikipedia.org/wiki/Theodahad;https://fr.wikipedia.org/wiki/Th%C3%A9odat;;;;;;;;;;;x
 W_L_206855;https://en.wikipedia.org/wiki/Guntram;https://fr.wikipedia.org/wiki/Gontran_(roi);;;;;;;;;;;x
 W_L_212873;https://en.wikipedia.org/wiki/Liuvigild;https://fr.wikipedia.org/wiki/L%C3%A9ovigild;;;;;;;;;;;x
 W_L_231004;https://en.wikipedia.org/wiki/Sigebert_I;https://fr.wikipedia.org/wiki/Sigebert_Ier;;;;;;;;;;;x


### PR DESCRIPTION
The character 190215 is not Theodric but Theodahad.