### PR TITLE
Made c_at_ta_if actually include Ta'if

### DIFF
--- a/WTWSMS/common/landed_titles/landed_titles.txt
+++ b/WTWSMS/common/landed_titles/landed_titles.txt
@@ -14892,8 +14892,7 @@ e_arabia = {
 			c_ranyah = {
 				color={ 45 210 186 }
 				color2={ 255 255 255 }
-					
-			
+				
 				b_ranyah = {				
 				}
 			}
@@ -14901,21 +14900,23 @@ e_arabia = {
 			c_at_ta_if = {
 				color={ 40 189 167 }
 				color2={ 255 255 255 }
-					
-			
-				b_at_ta_if = {				
+				
+				b_at_ta_if = {
+				}
+				b_qunfudhah = {
+				}
+				b_turubah = {
 				}
 			}
 			c_lidam = {
 				color={ 36 168 148 }
 				color2={ 255 255 255 }
-					
-			
+				
 				b_lidam = {				
 				}
 			}
-			}
-			
+		}
+		
 		d_makkah = {
 			color={ 22 105 93 }
 			color2={ 255 255 255 }
@@ -14951,17 +14952,11 @@ e_arabia = {
 				}
 				b_jeddah = {
 				}
-				b_taif = {
-				}
 				b_al_johfa = {
-				}
-				b_turubah = {
 				}
 				b_al_lith = {
 				}
 				b_jmumum = {
-				}
-				b_qunfudhah = {
 				}
 			}
 			c_lajj = {

--- a/WTWSMS/history/provinces/1587 - At Ta'if.txt
+++ b/WTWSMS/history/provinces/1587 - At Ta'if.txt
@@ -5,6 +5,8 @@ max_settlements = 1
 terrain = desert
 
 b_at_ta_if = castle
+b_turubah = city
+#b_qunfudhah = castle
 
 # Misc
 culture = ethiopian

--- a/WTWSMS/history/provinces/719 - Mecca.txt
+++ b/WTWSMS/history/provinces/719 - Mecca.txt
@@ -6,13 +6,10 @@ title = c_mecca
 # Settlements
 max_settlements = 7
 b_jeddah = city
-b_taif = castle
 b_al_lith = castle
 b_mecca = temple
 b_al_johfa = castle
-b_turubah = city
 #b_jmumum = castle
-#b_qunfudhah = castle
 
 # Misc
 culture = adnanite 


### PR DESCRIPTION
- removed duplicate b_taif
- moved b_qunfudhah and b_turubah to c_at_ta_if (b_qunfudhah because it's far beyond the province of Mecca on map and b_turubah because it's closer to Ta'if than Mecca)

Map comparison:
![adnotacja1](https://user-images.githubusercontent.com/29546927/39940542-e3cbee46-5559-11e8-8758-1c997962beed.png)
![adnotacja2](https://user-images.githubusercontent.com/29546927/39940543-e3ea6470-5559-11e8-8f3f-b15deca88d0f.png)



This fixes "Barony of Ta'if (b_taif) in Mecca province and County of At Ta'if (c_at_ta_if) duplicate"

