### PR TITLE
Add Euric as selectable character on Little Augustus bookmark screen

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -19,6 +19,7 @@ MINOR:
 - Made Odoacer's revolt landless
 - Added an unification of England decision, adapted on the basis of the Insular Flavour sub-mod by Boristus
 - Fixed Syagrius' age in Shattered Empire bookmark screen
+- Fixed Euric's government in Shattered Empire bookmark screen
 
 MAP/HISTORY:
 - Added historical rulers of the Irish Petty Kingdoms up to year 600 along with their families

--- a/WTWSMS/common/bookmarks/00_bookmarks.txt
+++ b/WTWSMS/common/bookmarks/00_bookmarks.txt
@@ -104,7 +104,7 @@ bm_little_augustus = {
 			properties="ak000b000000"
 			religion = arian
 			culture = visigothic
-			government = feudal_government
+			government = sub_roman_government
 			dynasty = 1042147
 		}
 	}
@@ -198,7 +198,7 @@ bm_the_older_gods = {
 			properties="ak000b000000"
 			religion = arian
 			culture = visigothic
-			government = feudal_government
+			government = sub_roman_government
 			dynasty = 1042147
 		}
 	}

--- a/WTWSMS/common/bookmarks/00_bookmarks.txt
+++ b/WTWSMS/common/bookmarks/00_bookmarks.txt
@@ -92,9 +92,6 @@ bm_little_augustus = {
 			dynasty = 1042151
 		}
 	}
-	
-	### These are not shown unless the player is viewing custom bookmarks
-	
 	selectable_character = {
 		id = 30 # Aiwareiks
 		age = 42
@@ -111,6 +108,9 @@ bm_little_augustus = {
 			dynasty = 1042147
 		}
 	}
+	
+	### These are not shown unless the player is viewing custom bookmarks
+	
 	selectable_character = {
 		id = 19 #Syagrius
 	}

--- a/WTWSMS/common/bookmarks/00_bookmarks.txt
+++ b/WTWSMS/common/bookmarks/00_bookmarks.txt
@@ -96,13 +96,26 @@ bm_little_augustus = {
 	### These are not shown unless the player is viewing custom bookmarks
 	
 	selectable_character = {
+		id = 30 # Aiwareiks
+		age = 42
+		name = ERA_CHAR_NAME_30
+		title = k_visigoths
+		title_name = k_visigoths
+		
+		character = {
+			dna="spmzekpekit" # From pre-2.5 save
+			properties="ak000b000000"
+			religion = arian
+			culture = visigothic
+			government = feudal_government
+			dynasty = 1042147
+		}
+	}
+	selectable_character = {
 		id = 19 #Syagrius
 	}
 	selectable_character = {
 		id = 93 #Genseric
-	}
-	selectable_character = {
-		id = 30 #Aiwareiks
 	}
 	#Interesting Vassals
 	selectable_character = {


### PR DESCRIPTION
With #436 Odoacer was removed from selectable characters for Little Augustus. To fill the gap I reused Euric, who already has character info for Shattered Empire bookmark.